### PR TITLE
Fix for release version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ Thumbs.db
 .buildpath
 vendor/.git
 .env*.php*
-
+.idea
 
 environment/*
 www/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,17 @@ RUN apt-get -y update
 RUN apt-get install -y php7.4 libapache2-mod-php7.4
 RUN apt-get install -y php7.4-fpm libapache2-mod-fcgid
 RUN apt-get install -y php7.4-mysql
-RUN apt-get install -y php7.4-curl php7.4-intl php7.4-zip php7.4-imap
+RUN apt-get install -y php7.4-curl php7.4-intl php7.4-zip php7.4-imap php7.4-gd
 
 RUN a2enmod rewrite
 RUN a2enconf php7.4-fpm
 
-RUN apt install -y php7.4-xml php7.4-mbstring 
+RUN apt install -y php7.4-xml php7.4-mbstring
 RUN apt install -y zlib1g-dev libxml2-dev
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y nodejs \
-    npm    
+    npm
 
 RUN npm install -g @angular/cli
 RUN npm install --global yarn

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 3. Clone this repo
 
-4. Download and unzip SuiteCRM 8 into the www folder, ensuring to name the folder "SuiteCRM", you can download it from here: https://suitecrm.com/suitecrm-8-beta-preview/
-> **TIP** \
-> Click the big red button that says something to the effect of "DOWNLOAD BETA X"
+4. Download and unzip SuiteCRM 8 into the www folder, ensuring to name the folder "SuiteCRM", you can download it from here: https://docs.suitecrm.com/8.x/admin/releases/8.0/#_8_0_1
 
 4. Run docker-compose up -d
 from root folder created when the repo is cloned,
@@ -19,7 +17,8 @@ and wait for images to be pulled and containers to be created
 6. To complete installation run `docker exec -it suitecrm_suitecrm_1 /bin/bash` to access the web server container. The installation can then be run using the command stored in `./helper/SuiteCRM install.txt`. This will setup SuiteCRM using recommended values for config as well as a default admin user.
 >**TIP** \
 >Along with the Web Server and MYSQL, you will also find phpMyAdmin running at `http://localhost:8181` \
->Username and password to access SuiteCRM 8 is `admin` | `admin`
+>Username and password to access SuiteCRM 8 is `admin` | `admin`\
+>The hostname of the db is `mysql_crm`. (You need this Information, if you want to configure the crm with over the webinterface)
 
 > **REMEMBER** \
 > For a non test/local environment don't forget to change the username and password of the admin user to something that only you know and can remember!

--- a/docker/config/php/php.ini
+++ b/docker/config/php/php.ini
@@ -852,7 +852,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 10M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
As of now it seems necessary to set the upload size for the release version 8.0.1 of SuiteCRM in the php.ini to a minimum of 6MB. Furthermore the php package php7.4-gd seems to be required.