### PR TITLE
Fixed DocumentRoot being taken from default config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN npm install --global yarn
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
+# Disable default site and enable custom site
+RUN a2dissite 000-default.conf
+
 WORKDIR /var/www/html/
 RUN chown -R www-data:www-data .
 RUN chmod -R 755 .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       #SuiteCRM Application Folder
       - ./www:/var/www/html
+        #env File
+      - ./environment/.env:/var/www/html/SuiteCRM/.env
       #SuiteCRM Log Folder
       - ./logs/SuiteCRM:/var/www/html/SuiteCRM/logs
       - ./logs/SuiteCRM_Core/suitecrm.log:/var/www/SuiteCRM/public/legacy/suitecrm.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     volumes:
       #SuiteCRM Application Folder
       - ./www:/var/www/html
-        #env File
-      - ./environment/.env:/var/www/html/SuiteCRM/.env
       #SuiteCRM Log Folder
       - ./logs/SuiteCRM:/var/www/html/SuiteCRM/logs
       - ./logs/SuiteCRM_Core/suitecrm.log:/var/www/SuiteCRM/public/legacy/suitecrm.log

--- a/docker/config/apache/sites.conf
+++ b/docker/config/apache/sites.conf
@@ -1,16 +1,20 @@
 <VirtualHost *:80>
-    <Directory /var/www/html/SuiteCRM/public/>
+    ServerName localhost
+    DocumentRoot "/var/www/html/SuiteCRM/public/"
+
+    <Directory "/var/www/html/SuiteCRM/public/">
         Options Indexes FollowSymLinks
         AllowOverride All
         Require all granted
+        DirectoryIndex index.php
     </Directory>
-        ServerName localhost
-        DocumentRoot /var/www/html/SuiteCRM/
+        
     <IfModule setenvif_module>
         SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
     </IfModule>
-    RedirectMatch ^/$ /public/
+
 </VirtualHost>
+
 # <VirtualHost *:443>
 #     <Directory /var/www/html/SuiteCRM/public/>
 #         Options Indexes FollowSymLinks


### PR DESCRIPTION
- Disabled default apache virtualhost config file during docker build. 
- Changed sites.conf Documentroot to the `SuiteCRM/public` folder and removed the route logic.
- Added env file to volumes to fix the following error:
```
PHP Fatal error:  Uncaught Symfony\\Component\\Dotenv\\Exception\\PathException: Unable to read the "/var/www/html/SuiteCRM/.env" environment file.
```
